### PR TITLE
Use env for contract address

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ pnpm dev
 bun dev
 ```
 
+## Environment Variables
+
+Create a `.env.local` file at the project root and define your deployed contract address:
+
+```bash
+NEXT_PUBLIC_CONTRACT_ADDRESS=<your contract address>
+```
+
+The frontend uses this variable when initializing the Voting contract.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/components/RegisterVoter.tsx
+++ b/components/RegisterVoter.tsx
@@ -11,6 +11,8 @@ import { Label } from "@/components/ui/label";
 import Voting from "../contracts/Voting.json"; // Assuming ABI is available
 import Link from "next/link"; // Import Link
 
+const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS as string;
+
 export default function RegisterVoter() {
   const [voterAddress, setVoterAddress] = useState("");
   const typedWeb3 = web3 as unknown as Web3;
@@ -20,10 +22,10 @@ export default function RegisterVoter() {
     console.log("Fetching accounts...");
     const accounts = await typedWeb3.eth.getAccounts();
     console.log("Accounts fetched:", accounts);
-     const contract = new typedWeb3.eth.Contract(
-       Voting.abi,
-       "0x5FbDB2315678afecb367f032d93F642f64180aa3"
-     ); // Replace with your contract address
+    const contract = new typedWeb3.eth.Contract(
+      Voting.abi,
+      CONTRACT_ADDRESS
+    );
 
     try {
       await contract.methods.registerVoter(voterAddress).send({ from: accounts[0] });

--- a/components/ViewAllVoters.tsx
+++ b/components/ViewAllVoters.tsx
@@ -6,13 +6,18 @@ import web3 from "../utils/web3";
 import Voting from "../contracts/Voting.json"; // Assuming ABI is available
 import "../components/styles/ViewAllVoters.css";
 
+const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS as string;
+
 export default function ViewAllVoters() {
   const [voters, setVoters] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchVoters = async () => {
-      const contract = new web3.eth.Contract(Voting.abi, "0x5FbDB2315678afecb367f032d93F642f64180aa3"); // Replace with your contract address
+      const contract = new web3.eth.Contract(
+        Voting.abi,
+        CONTRACT_ADDRESS
+      );
       try {
         const voterList = (await contract.methods.getAllVoters().call()) as string[];
         setVoters(voterList);

--- a/components/ViewVoter.tsx
+++ b/components/ViewVoter.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import Voting from "../contracts/Voting.json"; // Assuming ABI is available
 import "@/components/styles/ViewVoter.css";
 
+const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS as string;
+
 export default function ViewVoter() {
   const [voterAddress, setVoterAddress] = useState("");
   const [voterDetails, setVoterDetails] = useState<{
@@ -16,7 +18,10 @@ export default function ViewVoter() {
   } | null>(null);
 
   const fetchVoterDetails = async () => {
-    const contract = new web3.eth.Contract(Voting.abi, "0x5FbDB2315678afecb367f032d93F642f64180aa3"); // Replace with your contract address
+    const contract = new web3.eth.Contract(
+      Voting.abi,
+      CONTRACT_ADDRESS
+    );
     try {
       const details = (await contract.methods.getVoterDetails(voterAddress).call()) as {
         address: string;

--- a/components/VotingInterface.tsx
+++ b/components/VotingInterface.tsx
@@ -9,6 +9,8 @@ import Voting from "../contracts/Voting.json"; // Assuming ABI is available
 import "@/components/styles/VotingInterface.css";
 import Link from "next/link";
 
+const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS as string;
+
 const candidates = [
   { id: "1", name: "Alice" },
   { id: "2", name: "Bob" },
@@ -21,7 +23,10 @@ export default function VotingInterface() {
   const castVote = async (event: React.FormEvent) => {
     event.preventDefault();
     const accounts = await web3.eth.getAccounts();
-    const contract = new web3.eth.Contract(Voting.abi, "0x5FbDB2315678afecb367f032d93F642f64180aa3"); // Replace with your contract address
+    const contract = new web3.eth.Contract(
+      Voting.abi,
+      CONTRACT_ADDRESS
+    );
 
     try {
       const voterId = web3.utils.soliditySha3({ type: "address", value: accounts[0] });


### PR DESCRIPTION
## Summary
- read Voting contract address from `NEXT_PUBLIC_CONTRACT_ADDRESS`
- document required env var in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865dd74e3e8832cb5b35a8a60399de6