### PR TITLE
Update README with setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,44 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Voting DApp
 
-## Getting Started
+This repository combines a Hardhat project and a Next.js application for a simple blockchain based voting system.
 
-First, run the development server:
+## Install dependencies
+
+```bash
+npm install
+```
+
+## Run Hardhat tests
+
+```bash
+npx hardhat test
+```
+
+## Configure `.env.local`
+
+Create a `.env.local` file in the project root and set the address of your deployed `Voting` contract.
+
+```bash
+NEXT_PUBLIC_CONTRACT_ADDRESS=0xYourContractAddress
+```
+
+Additional variables can be added here as the project grows.
+
+## Build and start the Next.js app
+
+For a production build run:
+
+```bash
+npm run build
+npm start
+```
+
+During development you can instead use:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## IPFS integration plans
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Candidate images are currently referenced by URL. Future updates will store these assets and voting proofs on IPFS. Environment variables for IPFS gateways or API keys will be added to `.env.local` when this functionality lands.


### PR DESCRIPTION
## Summary
- replace Next.js boilerplate README with project-specific instructions
- explain installing dependencies, running Hardhat tests, configuring `.env.local`, building the frontend, and future IPFS plans

## Testing
- `npm install`
- `npx hardhat test` *(fails: couldn't download compiler version)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866224ff4f8832ca7545ca266bf7178