### PR TITLE
Add onlyOwner restriction to registerVoter

### DIFF
--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -29,7 +29,7 @@ contract Voting is Ownable {
         candidates[_candidateId] = Candidate(_candidateId, _name, _description, _imageUrl);
     }
 
-    function registerVoter(address _voterAddress) public {
+    function registerVoter(address _voterAddress) public onlyOwner {
         bytes32 voterId = keccak256(abi.encodePacked(_voterAddress));
         require(voters[voterId].voterId == bytes32(0), "Voter is already registered.");
         voters[voterId] = Voter(voterId, false, bytes32(0));

--- a/test/Voting.test.mjs
+++ b/test/Voting.test.mjs
@@ -54,6 +54,12 @@ describe("Voting Contract", function () {
     expect(hasVoted).to.equal(false);
   });
 
+  it("Should not allow non-owner to register a voter", async function () {
+    await expect(
+      voting.connect(addr1).registerVoter(addr2.address)
+    ).to.be.reverted;
+  });
+
   it("Should add a candidate", async function () {
     await voting.addCandidate("1", "Alice", "Description of Alice", "http://example.com/alice.jpg");
     const candidate = await voting.candidates("1");


### PR DESCRIPTION
## Summary
- restrict `registerVoter` to contract owner
- test that non-owners cannot register voters

## Testing
- `npx mocha test/Voting.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_686638d70cf4832ca258ff7898a54a13