### PR TITLE
Add candidate added event

### DIFF
--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -23,10 +23,12 @@ contract Voting is Ownable {
 
     event VoterRegistered(bytes32 voterId);
     event VoteCast(bytes32 voterId, bytes32 vote);
+    event CandidateAdded(string candidateId);
     event ResultsAnnounced(string candidateId, uint256 voteCount);
 
     function addCandidate(string memory _candidateId, string memory _name, string memory _description, string memory _imageUrl) public onlyOwner {
         candidates[_candidateId] = Candidate(_candidateId, _name, _description, _imageUrl);
+        emit CandidateAdded(_candidateId);
     }
 
     function registerVoter(address _voterAddress) public {

--- a/test/Voting.test.mjs
+++ b/test/Voting.test.mjs
@@ -55,7 +55,16 @@ describe("Voting Contract", function () {
   });
 
   it("Should add a candidate", async function () {
-    await voting.addCandidate("1", "Alice", "Description of Alice", "http://example.com/alice.jpg");
+    await expect(
+      voting.addCandidate(
+        "1",
+        "Alice",
+        "Description of Alice",
+        "http://example.com/alice.jpg"
+      )
+    )
+      .to.emit(voting, "CandidateAdded")
+      .withArgs("1");
     const candidate = await voting.candidates("1");
     expect(candidate.candidateId).to.equal("1");
     expect(candidate.name).to.equal("Alice");


### PR DESCRIPTION
## Summary
- add `CandidateAdded` event to `Voting` contract
- emit event when new candidate is added
- test for `CandidateAdded` event emission

## Testing
- `npx hardhat test --no-compile`

------
https://chatgpt.com/codex/tasks/task_e_68663a0c36b8832c8e28bad01967eae9