### PR TITLE
Add npm test script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Running Tests
+
+Run the Hardhat test suite with:
+
+```bash
+npm test
+```
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "hardhat test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add a `test` script using Hardhat
- document how to run tests

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f25d46d8832c9f7d05626bd8a64e